### PR TITLE
Feature autoreload

### DIFF
--- a/xdc/MainForm.cs
+++ b/xdc/MainForm.cs
@@ -103,10 +103,10 @@ namespace xdc
         {
             if (started)
             {
-                if (_fileLoader != null && _fileLoader.AllowsOpenFileDialog)
+                /*if (_fileLoader != null && _fileLoader.AllowsOpenFileDialog)
                 {
                     openToolStripMenuItem.Enabled = true;
-                }
+                }*/
 
                 runToolStripMenuItem.Enabled = true;
                 stepInToolStripMenuItem.Enabled = true;
@@ -125,8 +125,8 @@ namespace xdc
 
                 startListeningToolStripMenuItem.Enabled = true;
                 stopDebuggingToolStripMenuItem.Enabled = false;
-                openToolStripMenuItem.Enabled = false;
-                closeToolStripMenuItem.Enabled = false;
+                //openToolStripMenuItem.Enabled = false;
+                //closeToolStripMenuItem.Enabled = false;
             }
 
         }


### PR DESCRIPTION
Made two changes.
1. Made it possible to manually open/close files. For example if I want to add a break point to a file at a specific line I can now just open the file place a break point then start the debugging process.
2. Added a auto reload feature. It check the opened files every 1000ms and reloads them if the last modification time was altered. I guess a better solution would be to do this on focus of the window but I'm no WinForm expert so I wasn't able to fix that. It would be cool if it was possible to retain the break point locations on reload I guess it would be possible with some diff algorithm comparing the new file contents to the old contents.
